### PR TITLE
Refactored code to avoid using jquery to evaluate the number of items…

### DIFF
--- a/scrape.js
+++ b/scrape.js
@@ -214,7 +214,7 @@ function clickDesignerFilter(designer) {
 
 function numFeedItems() {
   return casper.evaluate(function () {
-    return $("div.feed-item").length;
+    return document.querySelectorAll("div.feed-item").length;
   });
 }
 


### PR DESCRIPTION
… scraped as jQuery requires additional setup beyond the boilerplate casperjs build and beyond what is described in the README