### PR TITLE
Added not(.empty-item) filter to selector to avoid counting the divs …

### DIFF
--- a/scrape.js
+++ b/scrape.js
@@ -214,7 +214,7 @@ function clickDesignerFilter(designer) {
 
 function numFeedItems() {
   return casper.evaluate(function () {
-    return document.querySelectorAll("div.feed-item").length;
+    return document.querySelectorAll("div.feed-item:not(.empty-item)").length;
   });
 }
 


### PR DESCRIPTION
…that represent placeholders (usually there are 3 at the end of the feed)